### PR TITLE
Make play_routes_compiler attribute public

### DIFF
--- a/play-routes/play-routes.bzl
+++ b/play-routes/play-routes.bzl
@@ -90,7 +90,7 @@ play_routes = rule(
       doc = "If true, include the imports the Play project includes by default.",
       default = False
     ),
-    "_play_routes_compiler": attr.label(
+    "play_routes_compiler": attr.label(
       executable = True,
       cfg = "host",
       allow_files = True,

--- a/play-routes/play-routes.bzl
+++ b/play-routes/play-routes.bzl
@@ -49,7 +49,7 @@ def _impl(ctx):
     outputs = [gendir],
     arguments = args,
     progress_message = "Compiling play routes",
-    executable = ctx.executable._play_routes_compiler,
+    executable = ctx.executable.play_routes_compiler,
   )
 
   # TODO: something more portable


### PR DESCRIPTION
After running into the issues detailed in #5, I decided the easiest way to move forward for me was to compile your routes_compiler (and your twirl compiler, for that matter) internally, and only pull in your Bazel rules. This required altering them in order to be able to set the `play_routes_compiler` attribute. Is this an option you would be interested in supporting for users generally? 