### PR TITLE
WIP: Make rule_play_routes self-contained, fixing cross-WORKSPACE dependency issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,9 @@ http_archive(
   url = "https://github.com/lucidsoftware/rules_play_routes/archive/{}.zip".format(rules_play_routes_version),
 )
 
-RULES_JVM_EXTERNAL_TAG = "2.1"
-http_archive(
-    name = "rules_jvm_external",
-    sha256 = "515ee5265387b88e4547b34a57393d2bcb1101314bcc5360ec7a482792556f42",
-    strip_prefix = "rules_jvm_external-{}".format(RULES_JVM_EXTERNAL_TAG),
-    type = "zip",
-    url = "https://github.com/bazelbuild/rules_jvm_external/archive/{}.zip".format(RULES_JVM_EXTERNAL_TAG),
-)
+load("@rules_play_routes//play-routes:play-routes.bzl", "play_repositories")
 
-load("@io_bazel_rules_play_routes//:workspace.bzl", "play_routes_repositories")
-play_routes_repositories()
+play_repositories()
 ```
 
 This installs `rules_play_routes` to your `WORKSPACE` at the specified commit. Update the commit as needed.


### PR DESCRIPTION
Opening this up for discussion, this PR presents a mechanism by which we can turn this into a self-contained ruleset such that Bazel projects that depend on this ruleset don't need to care about which underlying Scala rules implementation is used.

This also updates to Play 2.7.0.

Consumers only need to add a fragment like this to their WORKSPACE.
```
rules_play_routes_release = ...
http_archive(
    name = "rules_play_routes",
    strip_prefix = "rules_play_routes-%s" % rules_play_routes_release,
    type = "tar.gz",
    url = ...
)

load("@rules_play_routes//play-routes:play-routes.bzl", "play_repositories")

play_repositories()
```

The main technique used here is to use a Bazel repository rule to pull down the routes compiler, built as a deploy jar, as an external dependency. In this example I'm using a Github release page as the destination to pull the artifact from, but it could be any place where artifacts could be pulled from. The full solution requires a little more work beyond this.

1. Hooking up CI to build the deploy JAR automatically.
2. Hooking up CI to upload the deploy JAR to a release page automatically.