### PR TITLE
Make the play_routes_compiler attribute public

### DIFF
--- a/compiler-cli/BUILD.bazel
+++ b/compiler-cli/BUILD.bazel
@@ -1,0 +1,6 @@
+java_binary(
+  name = "compiler-cli",
+  runtime_deps = ["@play_routes//:com_lucidchart_play_routes_compiler_cli"],
+  main_class = "rulesplayroutes.routes.CommandLinePlayRoutesCompiler",
+  visibility = ["//visibility:public"]
+)

--- a/docs/stardoc/play-routes.md
+++ b/docs/stardoc/play-routes.md
@@ -5,7 +5,7 @@
 ## play_routes
 
 <pre>
-play_routes(<a href="#play_routes-name">name</a>, <a href="#play_routes-generate_reverse_router">generate_reverse_router</a>, <a href="#play_routes-include_play_imports">include_play_imports</a>, <a href="#play_routes-namespace_reverse_router">namespace_reverse_router</a>, <a href="#play_routes-routes_generator">routes_generator</a>, <a href="#play_routes-routes_imports">routes_imports</a>, <a href="#play_routes-srcs">srcs</a>)
+play_routes(<a href="#play_routes-name">name</a>, <a href="#play_routes-generate_reverse_router">generate_reverse_router</a>, <a href="#play_routes-include_play_imports">include_play_imports</a>, <a href="#play_routes-namespace_reverse_router">namespace_reverse_router</a>, <a href="#play_routes-play_routes_compiler">play_routes_compiler</a>, <a href="#play_routes-routes_generator">routes_generator</a>, <a href="#play_routes-routes_imports">routes_imports</a>, <a href="#play_routes-srcs">srcs</a>)
 </pre>
 
 Compiles Play routes files templates to Scala sources files.
@@ -52,6 +52,12 @@ Compiles Play routes files templates to Scala sources files.
         <p>
           Whether the reverse router should be namespaced. Useful if you have many routers that use the same actions.
         </p>
+      </td>
+    </tr>
+    <tr id="play_routes-play_routes_compiler">
+      <td><code>play_routes_compiler</code></td>
+      <td>
+        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; optional
       </td>
     </tr>
     <tr id="play_routes-routes_generator">

--- a/play-routes/BUILD
+++ b/play-routes/BUILD
@@ -38,10 +38,3 @@ bzl_library(
     name = "jdk_toolchain_utils",
     srcs = ["@bazel_tools//tools/jdk:toolchain_utils.bzl"],
 )
-
-java_binary(
-  name = "compiler-cli",
-  runtime_deps = ["@play_routes//:com_lucidchart_play_routes_compiler_cli"],
-  main_class = "rulesplayroutes.routes.CommandLinePlayRoutesCompiler",
-  visibility = ["//visibility:public"]
-)

--- a/play-routes/play-routes.bzl
+++ b/play-routes/play-routes.bzl
@@ -49,7 +49,7 @@ def _impl(ctx):
     outputs = [gendir],
     arguments = args,
     progress_message = "Compiling play routes",
-    executable = ctx.executable._play_routes_compiler,
+    executable = ctx.executable.play_routes_compiler,
   )
 
   # TODO: something more portable
@@ -90,11 +90,11 @@ play_routes = rule(
       doc = "If true, include the imports the Play project includes by default.",
       default = False
     ),
-    "_play_routes_compiler": attr.label(
+    "play_routes_compiler": attr.label(
       executable = True,
       cfg = "host",
       allow_files = True,
-      default = Label("//play-routes:compiler-cli"),
+      default = Label("//compiler-cli"),
     ),
     "_zipper": attr.label(cfg = "host", default = "@bazel_tools//tools/zip:zipper", executable = True),
   },


### PR DESCRIPTION
Also moved the default compiler to its own package to stop leaking dependencies