### PR TITLE
support controlling forwards route generation

### DIFF
--- a/docs/stardoc/play-routes.md
+++ b/docs/stardoc/play-routes.md
@@ -5,7 +5,7 @@
 ## play_routes
 
 <pre>
-play_routes(<a href="#play_routes-name">name</a>, <a href="#play_routes-generate_reverse_router">generate_reverse_router</a>, <a href="#play_routes-include_play_imports">include_play_imports</a>, <a href="#play_routes-namespace_reverse_router">namespace_reverse_router</a>, <a href="#play_routes-play_routes_compiler">play_routes_compiler</a>, <a href="#play_routes-routes_generator">routes_generator</a>, <a href="#play_routes-routes_imports">routes_imports</a>, <a href="#play_routes-srcs">srcs</a>)
+play_routes(<a href="#play_routes-name">name</a>, <a href="#play_routes-generate_forwards_router">generate_forwards_router</a>, <a href="#play_routes-generate_reverse_router">generate_reverse_router</a>, <a href="#play_routes-include_play_imports">include_play_imports</a>, <a href="#play_routes-namespace_reverse_router">namespace_reverse_router</a>, <a href="#play_routes-play_routes_compiler">play_routes_compiler</a>, <a href="#play_routes-routes_generator">routes_generator</a>, <a href="#play_routes-routes_imports">routes_imports</a>, <a href="#play_routes-srcs">srcs</a>)
 </pre>
 
 Compiles Play routes files templates to Scala sources files.
@@ -24,6 +24,15 @@ Compiles Play routes files templates to Scala sources files.
         <a href="https://bazel.build/docs/build-ref.html#name">Name</a>; required
         <p>
           A unique name for this target.
+        </p>
+      </td>
+    </tr>
+    <tr id="play_routes-generate_forwards_router">
+      <td><code>generate_forwards_router</code></td>
+      <td>
+        Boolean; optional
+        <p>
+          Whether the forward router should be generated. Setting to false may help generate only the reverse routes
         </p>
       </td>
     </tr>

--- a/play-routes/play-routes.bzl
+++ b/play-routes/play-routes.bzl
@@ -44,6 +44,9 @@ def _impl(ctx):
   if ctx.attr.routes_generator:
     args = args + ["--routesGenerator={}".format(ctx.attr.routes_generator)]
 
+  if ctx.attr.generate_forwards_router == False:
+    args = args + ["--generateForwardsRouter={}".format(ctx.attr.generate_forwards_router)]
+
   ctx.actions.run(
     inputs = ctx.files.srcs,
     outputs = [gendir],
@@ -85,6 +88,10 @@ play_routes = rule(
     "namespace_reverse_router": attr.bool(
       doc = "Whether the reverse router should be namespaced. Useful if you have many routers that use the same actions.",
       default = False
+    ),
+    "generate_forwards_router": attr.bool(
+        doc = "Whether the forward router should be generated. Setting to false may help generate only the reverse routes",
+        default = True
     ),
     "include_play_imports": attr.bool(
       doc = "If true, include the imports the Play project includes by default.",


### PR DESCRIPTION
Play framework allows some projects to not depend on the whole service, but just depend on the reverse router, so that the respective projects can generate reverse routes links.

To accomplish that, we must generate forwards-routes and reverse-routes separately. 