### PR TITLE
Separate building play_routes to a helper to allow remote builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /lemur_rsa
 
 target/
+/.ijwb

--- a/play-routes/BUILD
+++ b/play-routes/BUILD
@@ -38,3 +38,9 @@ bzl_library(
     name = "jdk_toolchain_utils",
     srcs = ["@bazel_tools//tools/jdk:toolchain_utils.bzl"],
 )
+
+sh_binary(
+    name = "play-routes-helper",
+    srcs = ["play-routes-helper.sh"],
+    visibility = ["//visibility:public"]
+)

--- a/play-routes/play-routes-helper.sh
+++ b/play-routes/play-routes-helper.sh
@@ -5,11 +5,9 @@ set -e
 OUTPUT_DIR=$(mktemp -d)
 
 PREFIX=$1
-shift
-OUTPUT_SRCJAR=$1
-shift
-ZIPPER_PATH=$1
-shift
+OUTPUT_SRCJAR=$2
+ZIPPER_PATH=$3
+shift 3
 
 
 # substitute output path and execute the compiler command

--- a/play-routes/play-routes-helper.sh
+++ b/play-routes/play-routes-helper.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+OUTPUT_DIR=$(mktemp -d)
+
+PREFIX=$1
+shift
+OUTPUT_SRCJAR=$1
+shift
+ZIPPER_PATH=$1
+shift
+
+
+# substitute output path and execute the compiler command
+${*/REPLACE_ME_OUTPUT_PATH/$OUTPUT_DIR}
+
+# produce resulting source jar
+$ZIPPER_PATH c $OUTPUT_SRCJAR META-INF/= $(find -L $OUTPUT_DIR -type f | while read v; do echo "$PREFIX"${v#"$OUTPUT_DIR"}=$v; done)


### PR DESCRIPTION
Fix #38 
Two actions (executing routes compiler and then combining them with zipper) are collapsed into one, which allows for remote building