### PR TITLE
Remove mktemp usage from play-routes-helper.sh

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,8 +9,8 @@ common:ci --color=yes
 
 build:ci --verbose_failures
 build:ci --sandbox_debug
-build:ci --spawn_strategy=standalone
-build:ci --genrule_strategy=standalone
+#build:ci --spawn_strategy=standalone
+#build:ci --genrule_strategy=standalone
 
 test:ci --test_strategy=standalone
 test:ci --test_output=errors

--- a/play-routes/play-routes-helper.sh
+++ b/play-routes/play-routes-helper.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-OUTPUT_DIR=$(mktemp -d)
+mkdir output
+
+OUTPUT_DIR=output
 
 PREFIX=$1
 OUTPUT_SRCJAR=$2


### PR DESCRIPTION
As we are in a sandbox we do not need to use mktemp for creating an output
directory for compiling routes file to Scala.
This is escaping the sandbox that we should optimally avoid.