### PR TITLE
play-routes.bzl: use run() with use_default_shell_env to have access …

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,8 +9,6 @@ common:ci --color=yes
 
 build:ci --verbose_failures
 build:ci --sandbox_debug
-build:ci --spawn_strategy=standalone
-build:ci --genrule_strategy=standalone
 
 test:ci --test_strategy=standalone
 test:ci --test_output=errors

--- a/.bazelrc
+++ b/.bazelrc
@@ -9,6 +9,8 @@ common:ci --color=yes
 
 build:ci --verbose_failures
 build:ci --sandbox_debug
+build:ci --spawn_strategy=standalone
+build:ci --genrule_strategy=standalone
 
 test:ci --test_strategy=standalone
 test:ci --test_output=errors

--- a/play-routes/play-routes.bzl
+++ b/play-routes/play-routes.bzl
@@ -55,6 +55,7 @@ def _impl(ctx):
         ctx.executable.play_routes_compiler.path,
     ] + args,
     progress_message = "Compiling play routes",
+    use_default_shell_env = True,
     executable = ctx.executable._play_route_helper,
     tools = [ctx.executable.play_routes_compiler, ctx.executable._zipper]
   )


### PR DESCRIPTION
…to shell

When running on Nix we do not have access to default shell env if this
parameter is not set, thus failing route compilation.