### PR TITLE
Upgrade dependencies for Bazel 6 compatibility

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,7 @@ build --javabase="//:jdk"
 build --java_toolchain="@bazel_tools//tools/jdk:toolchain_hostjdk8"
 build --host_javabase="//:jdk"
 build --host_java_toolchain="@bazel_tools//tools/jdk:toolchain_hostjdk8"
+build --incompatible_java_common_parameters=false
 
 common:ci --color=yes
 

--- a/.bazelversion
+++ b/.bazelversion
@@ -1,1 +1,1 @@
-bazelbuild/3.3.0
+bazelbuild/4.2.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-node@v1
       - run: npm install -g @bazel/bazelisk
       - run: cat .bazelrc.ci >> .bazelrc
-      - run: ./scripts/skylint.sh
+      - run: ./scripts/format.sh check
       - run: ./test/run_all_tests.sh ci
       - run: ./scripts/gen-docs.sh && git diff --exit-code docs/
       - run: bazel shutdown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
       USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15]
-        bazel_version: [bazelbuild/3.2.0, bazelbuild/3.3.0]
+        os: [ubuntu-20.04]
+        bazel_version: [bazelbuild/4.2.4]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,14 @@
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+
+buildifier(
+    name = "buildifier",
+)
+
+buildifier(
+    name = "buildifier_check",
+    mode = "check",
+)
+
 java_runtime(
     name = "jdk",
     srcs = select({

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,13 +35,11 @@ http_archive(
 
 # rules_nodejs
 # To use the JavaScript version of Sass, we need to first install nodejs
-rules_nodejs_version = "1.4.1"
+rules_nodejs_version = "4.6.1"
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "6ea46cb994e349ceb255ec8340370883813cac825e6157770a15f11874d232d2",
-    strip_prefix = "rules_nodejs-{}".format(rules_nodejs_version),
-    type = "zip",
-    url = "https://github.com/bazelbuild/rules_nodejs/archive/{}.zip".format(rules_nodejs_version),
+    sha256 = "d63ecec7192394f5cc4ad95a115f8a6c9de55c60d56c1f08da79c306355e4654",
+    url = "https://github.com/bazelbuild/rules_nodejs/releases/download/{v}/rules_nodejs-{v}.tar.gz".format(v = rules_nodejs_version),
 )
 
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
@@ -154,3 +152,16 @@ bind(
   name = "default-play-routes-compiler-cli",
   actual = "//default-compiler-clis:scala_2_12_play_2_7"
 )
+
+rules_pkg_version = "0.7.0"
+
+http_archive(
+    name = "rules_pkg",
+    sha256 = "8a298e832762eda1830597d64fe7db58178aa84cd5926d76d5b744d6558941c2",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/{v}/rules_pkg-{v}.tar.gz".format(v = rules_pkg_version),
+        "https://github.com/bazelbuild/rules_pkg/releases/download/{v}/rules_pkg-{v}.tar.gz".format(v =rules_pkg_version),
+    ],
+)
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+rules_pkg_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,6 +4,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # rules_jvm_external
 RULES_JVM_EXTERNAL_TAG = "4.2"
+
 http_archive(
     name = "rules_jvm_external",
     sha256 = "cd1a77b7b02e8e008439ca76fd34f5b07aecb8c752961f9640dea15e9e5ba1ca",
@@ -14,17 +15,24 @@ http_archive(
 
 # Load dependencies
 load("//:workspace.bzl", "play_routes_repositories")
+
 play_routes_repositories("2.7")
+
 load("@play_routes//:defs.bzl", play_routes_pinned_maven_install = "pinned_maven_install")
+
 play_routes_pinned_maven_install()
 
 load("//:test_workspace.bzl", "play_routes_test_repositories")
+
 play_routes_test_repositories()
+
 load("@play_routes_test//:defs.bzl", play_routes_test_pinned_maven_install = "pinned_maven_install")
+
 play_routes_test_pinned_maven_install()
 
 # Skylib
 skylib_version = "1.0.2"  # update this as needed
+
 http_archive(
     name = "bazel_skylib",
     sha256 = "64ad2728ccdd2044216e4cec7815918b7bb3bb28c95b7e9d951f9d4eccb07625",
@@ -36,6 +44,7 @@ http_archive(
 # rules_nodejs
 # To use the JavaScript version of Sass, we need to first install nodejs
 rules_nodejs_version = "4.6.1"
+
 http_archive(
     name = "build_bazel_rules_nodejs",
     sha256 = "d63ecec7192394f5cc4ad95a115f8a6c9de55c60d56c1f08da79c306355e4654",
@@ -43,10 +52,12 @@ http_archive(
 )
 
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
+
 node_repositories(package_json = [])
 
 # rules_sass
-rules_sass_version = "1.26.2" # update this as needed
+rules_sass_version = "1.26.2"  # update this as needed
+
 http_archive(
     name = "io_bazel_rules_sass",
     sha256 = "a31026741e4af6f1e5bcc9cce23db0549ecdea6270c8919da09110886102eb8e",
@@ -54,14 +65,18 @@ http_archive(
     type = "zip",
     url = "https://github.com/bazelbuild/rules_sass/archive/{}.zip".format(rules_sass_version),
 )
+
 load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
+
 rules_sass_dependencies()
 
 load("@io_bazel_rules_sass//sass:sass_repositories.bzl", "sass_repositories")
+
 sass_repositories()
 
 # Skydoc
-skydoc_version = "0.3.0" # update this as needed
+skydoc_version = "0.3.0"  # update this as needed
+
 http_archive(
     name = "io_bazel_skydoc",
     sha256 = "8762a212cff5f81505a1632630edcfe9adce381479a50a03c968bd2fc217972d",
@@ -123,7 +138,9 @@ http_archive(
     type = "zip",
     url = "https://github.com/protocolbuffers/protobuf/archive/v{}.zip".format(protobuf_version),
 )
+
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
 protobuf_deps()
 
 jdk_build_file_content = """
@@ -157,7 +174,8 @@ http_archive(
 
 # higherkindness/rules_scala (used for tests only)
 # TODO: Move tests into their own worskpace s.t. we don't need their dependenices here
-rules_scala_annex_version = "ff423d8bdd0e5383f8f2c048ffd7704bb51a91bf" # update this as needed
+rules_scala_annex_version = "ff423d8bdd0e5383f8f2c048ffd7704bb51a91bf"  # update this as needed
+
 http_archive(
     name = "rules_scala_annex",
     sha256 = "ae53e9ed5fecadc7baf4637b88109471602be73dda4e5ff6b4bf1767932703c0",
@@ -172,16 +190,20 @@ bind(
 )
 
 load("@rules_scala_annex//rules/scala:workspace.bzl", "scala_register_toolchains", "scala_repositories")
+
 scala_repositories()
+
 load("@annex//:defs.bzl", annex_pinned_maven_install = "pinned_maven_install")
+
 annex_pinned_maven_install()
+
 scala_register_toolchains()
 
 # TODO: Once the tests are in their own workspaces, we might want to add a basic test for each of the defaults
 # This would require a separate workspace for each compiler being tested
 bind(
-  name = "default-play-routes-compiler-cli",
-  actual = "//default-compiler-clis:scala_2_12_play_2_7"
+    name = "default-play-routes-compiler-cli",
+    actual = "//default-compiler-clis:scala_2_12_play_2_7",
 )
 
 rules_pkg_version = "0.7.0"
@@ -191,8 +213,10 @@ http_archive(
     sha256 = "8a298e832762eda1830597d64fe7db58178aa84cd5926d76d5b744d6558941c2",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/{v}/rules_pkg-{v}.tar.gz".format(v = rules_pkg_version),
-        "https://github.com/bazelbuild/rules_pkg/releases/download/{v}/rules_pkg-{v}.tar.gz".format(v =rules_pkg_version),
+        "https://github.com/bazelbuild/rules_pkg/releases/download/{v}/rules_pkg-{v}.tar.gz".format(v = rules_pkg_version),
     ],
 )
+
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
 rules_pkg_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -69,22 +69,53 @@ http_archive(
     type = "zip",
     url = "https://github.com/bazelbuild/skydoc/archive/{}.zip".format(skydoc_version),
 )
+
 load("@io_bazel_skydoc//skylark:skylark.bzl", "skydoc_repositories")
+
 skydoc_repositories()
 
-# For Skylint
-# Once https://github.com/bazelbuild/bazel/issues/4086 is done, this should be
-# much simpler
-bazel_version = "0.27.0"
+# com_github_bazelbuild_buildtools
+
+buildtools_tag = "0.29.0"
+
+buildtools_sha256 = "05eb52437fb250c7591dd6cbcfd1f9b5b61d85d6b20f04b041e0830dd1ab39b3"
+
 http_archive(
-    name = "io_bazel",
-    sha256 = "2d86797a5b96163b7f5e9cbb8f09cc919066e7ee0fe1a614b79680ae36a14ef3",
-    strip_prefix = "bazel-{}".format(bazel_version),
-    urls = ["https://github.com/bazelbuild/bazel/archive/{}.zip".format(bazel_version)],
+    name = "com_github_bazelbuild_buildtools",
+    sha256 = buildtools_sha256,
+    strip_prefix = "buildtools-{}".format(buildtools_tag),
+    url = "https://github.com/bazelbuild/buildtools/archive/{}.zip".format(buildtools_tag),
 )
-# Also for Skylint. Comes from
+
+load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_dependencies")
+
+buildifier_dependencies()
+
+# io_bazel_rules_go (for buildifier)
+
+rules_go_tag = "v0.28.0"
+
+rules_go_sha256 = "8e968b5fcea1d2d64071872b12737bbb5514524ee5f0a4f54f5920266c261acb"
+
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = rules_go_sha256,
+    urls = [
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/{tag}/rules_go-{tag}.zip".format(tag = rules_go_tag),
+        "https://github.com/bazelbuild/rules_go/releases/download/{tag}/rules_go-{tag}.zip".format(tag = rules_go_tag),
+    ],
+)
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains(version = "1.17")
+
+# Also for buildifier
 # https://github.com/cgrushko/proto_library/blob/master/WORKSPACE
 protobuf_version = "3.11.4"
+
 http_archive(
     name = "com_google_protobuf",
     sha256 = "9748c0d90e54ea09e5e75fb7fac16edce15d2028d4356f32211cfa3c0e956564",

--- a/play-routes/BUILD
+++ b/play-routes/BUILD
@@ -42,5 +42,5 @@ bzl_library(
 sh_binary(
     name = "play-routes-helper",
     srcs = ["play-routes-helper.sh"],
-    visibility = ["//visibility:public"]
+    visibility = ["//visibility:public"],
 )

--- a/play-routes/BUILD
+++ b/play-routes/BUILD
@@ -2,7 +2,7 @@
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@io_bazel_skydoc//stardoc:stardoc.bzl", "stardoc")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
 [

--- a/play-routes/play-routes.bzl
+++ b/play-routes/play-routes.bzl
@@ -7,113 +7,113 @@ on Play routes files
 gendir_base_path = "play/routes"
 
 play_imports = [
-  "controllers.Assets.Asset",
+    "controllers.Assets.Asset",
 ]
 
 PlayRoutesInfo = provider(fields = {"srcjar": "The source jar created by this target."})
 
 def _sanitize_string_for_usage(s):
-  res_array = []
-  for i in range(len(s)):
-    c = s[i]
-    if c.isalnum() or c == ".":
-      res_array.append(c)
-    else:
-      res_array.append("_")
-  return "".join(res_array)
+    res_array = []
+    for i in range(len(s)):
+        c = s[i]
+        if c.isalnum() or c == ".":
+            res_array.append(c)
+        else:
+            res_array.append("_")
+    return "".join(res_array)
 
 def _format_import_args(imports):
-  return ["--routesImport={}".format(i) for i in imports]
+    return ["--routesImport={}".format(i) for i in imports]
 
 def _impl(ctx):
-  prefix = ctx.label.package + "/" + gendir_base_path + "/" + _sanitize_string_for_usage(ctx.attr.name)
-  paths = [f.path for f in ctx.files.srcs]
-  args = ["REPLACE_ME_OUTPUT_PATH"] + [",".join(paths)]
+    prefix = ctx.label.package + "/" + gendir_base_path + "/" + _sanitize_string_for_usage(ctx.attr.name)
+    paths = [f.path for f in ctx.files.srcs]
+    args = ["REPLACE_ME_OUTPUT_PATH"] + [",".join(paths)]
 
-  if ctx.attr.include_play_imports:
-    args = args + _format_import_args(play_imports)
+    if ctx.attr.include_play_imports:
+        args = args + _format_import_args(play_imports)
 
-  args = args + _format_import_args(ctx.attr.routes_imports)
+    args = args + _format_import_args(ctx.attr.routes_imports)
 
-  if ctx.attr.generate_reverse_router:
-    args = args + ["--generateReverseRouter"]
+    if ctx.attr.generate_reverse_router:
+        args = args + ["--generateReverseRouter"]
 
-  if ctx.attr.namespace_reverse_router:
-    args = args + ["--namespaceReverserRouter"]
+    if ctx.attr.namespace_reverse_router:
+        args = args + ["--namespaceReverserRouter"]
 
-  if ctx.attr.routes_generator:
-    args = args + ["--routesGenerator={}".format(ctx.attr.routes_generator)]
+    if ctx.attr.routes_generator:
+        args = args + ["--routesGenerator={}".format(ctx.attr.routes_generator)]
 
-  if ctx.attr.generate_forwards_router == False:
-    args = args + ["--generateForwardsRouter={}".format(ctx.attr.generate_forwards_router)]
+    if ctx.attr.generate_forwards_router == False:
+        args = args + ["--generateForwardsRouter={}".format(ctx.attr.generate_forwards_router)]
 
-  ctx.actions.run(
-    inputs = ctx.files.srcs,
-    outputs = [ctx.outputs.srcjar],
-    arguments = [
-        prefix,
-        ctx.outputs.srcjar.path,
-        ctx.executable._zipper.path,
-        ctx.executable.play_routes_compiler.path,
-    ] + args,
-    progress_message = "Compiling play routes",
-    use_default_shell_env = True,
-    executable = ctx.executable._play_route_helper,
-    tools = [ctx.executable.play_routes_compiler, ctx.executable._zipper]
-  )
-
-  return [
-    PlayRoutesInfo(
-      srcjar = ctx.outputs.srcjar,
+    ctx.actions.run(
+        inputs = ctx.files.srcs,
+        outputs = [ctx.outputs.srcjar],
+        arguments = [
+            prefix,
+            ctx.outputs.srcjar.path,
+            ctx.executable._zipper.path,
+            ctx.executable.play_routes_compiler.path,
+        ] + args,
+        progress_message = "Compiling play routes",
+        use_default_shell_env = True,
+        executable = ctx.executable._play_route_helper,
+        tools = [ctx.executable.play_routes_compiler, ctx.executable._zipper],
     )
-  ]
+
+    return [
+        PlayRoutesInfo(
+            srcjar = ctx.outputs.srcjar,
+        ),
+    ]
 
 play_routes = rule(
-  implementation = _impl,
-  doc = "Compiles Play routes files templates to Scala sources files.",
-  attrs = {
-    "srcs": attr.label_list(
-      doc = "Play routes files",
-      allow_files = True,
-      mandatory = True
-    ),
-    "routes_imports": attr.string_list(
-      doc = "Additional imports to import to the Play routes",
-    ),
-    "routes_generator": attr.string(
-      doc = "The full class of the routes generator, e.g., `play.routes.compiler.InjectedRoutesGenerator`",
-      default = ""
-    ),
-    "generate_reverse_router": attr.bool(
-      doc = "Whether the reverse router should be generated. Setting to false may reduce compile times if it's not needed.",
-      default = False
-    ),
-    "namespace_reverse_router": attr.bool(
-      doc = "Whether the reverse router should be namespaced. Useful if you have many routers that use the same actions.",
-      default = False
-    ),
-    "generate_forwards_router": attr.bool(
-        doc = "Whether the forward router should be generated. Setting to false may help generate only the reverse routes",
-        default = True
-    ),
-    "include_play_imports": attr.bool(
-      doc = "If true, include the imports the Play project includes by default.",
-      default = False
-    ),
-    "play_routes_compiler": attr.label(
-      executable = True,
-      cfg = "host",
-      allow_files = True,
-      default = Label("//external:default-play-routes-compiler-cli"),
-    ),
-    "_play_route_helper": attr.label(
-      executable = True,
-      cfg = "host",
-      default = Label("@io_bazel_rules_play_routes//play-routes:play-routes-helper"),
-    ),
-    "_zipper": attr.label(cfg = "host", default = "@bazel_tools//tools/zip:zipper", executable = True),
-  },
-  outputs = {
-    "srcjar": "play_routes_%{name}.srcjar",
-  }
+    implementation = _impl,
+    doc = "Compiles Play routes files templates to Scala sources files.",
+    attrs = {
+        "srcs": attr.label_list(
+            doc = "Play routes files",
+            allow_files = True,
+            mandatory = True,
+        ),
+        "routes_imports": attr.string_list(
+            doc = "Additional imports to import to the Play routes",
+        ),
+        "routes_generator": attr.string(
+            doc = "The full class of the routes generator, e.g., `play.routes.compiler.InjectedRoutesGenerator`",
+            default = "",
+        ),
+        "generate_reverse_router": attr.bool(
+            doc = "Whether the reverse router should be generated. Setting to false may reduce compile times if it's not needed.",
+            default = False,
+        ),
+        "namespace_reverse_router": attr.bool(
+            doc = "Whether the reverse router should be namespaced. Useful if you have many routers that use the same actions.",
+            default = False,
+        ),
+        "generate_forwards_router": attr.bool(
+            doc = "Whether the forward router should be generated. Setting to false may help generate only the reverse routes",
+            default = True,
+        ),
+        "include_play_imports": attr.bool(
+            doc = "If true, include the imports the Play project includes by default.",
+            default = False,
+        ),
+        "play_routes_compiler": attr.label(
+            executable = True,
+            cfg = "host",
+            allow_files = True,
+            default = Label("//external:default-play-routes-compiler-cli"),
+        ),
+        "_play_route_helper": attr.label(
+            executable = True,
+            cfg = "host",
+            default = Label("@io_bazel_rules_play_routes//play-routes:play-routes-helper"),
+        ),
+        "_zipper": attr.label(cfg = "host", default = "@bazel_tools//tools/zip:zipper", executable = True),
+    },
+    outputs = {
+        "srcjar": "play_routes_%{name}.srcjar",
+    },
 )

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [ "$1" != check ]; then
+    bazel run buildifier
+else
+    bazel run buildifier_check
+fi

--- a/scripts/skylint.sh
+++ b/scripts/skylint.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-echo "Running Skylint"
-skylint_path=src/tools/skylark/java/com/google/devtools/skylark/skylint
-bazel build @io_bazel//${skylint_path}:Skylint \
-  && find "$(bazel info workspace)" -type f -name '*.bzl' \
-  -a -not -path "$(bazel info workspace)/external-tools*" \
-  | xargs "$(bazel info bazel-bin)/external/io_bazel/${skylint_path}/Skylint"

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -2,37 +2,37 @@ load("@rules_scala_annex//rules:scala.bzl", "scala_test")
 load("//play-routes:play-routes.bzl", "play_routes")
 
 play_routes(
-  name = "play-routes",
-  srcs = ["conf/routes"],
-  include_play_imports = True,
+    name = "play-routes",
+    srcs = ["conf/routes"],
+    include_play_imports = True,
 )
 
 play_routes(
-  name = "play-routes-basic1",
-  srcs = ["conf/basic1.routes"],
-  include_play_imports = True,
+    name = "play-routes-basic1",
+    srcs = ["conf/basic1.routes"],
+    include_play_imports = True,
 )
 
 play_routes(
-  name = "play-routes-basic2",
-  srcs = ["conf/basic2.routes"],
-  include_play_imports = True,
+    name = "play-routes-basic2",
+    srcs = ["conf/basic2.routes"],
+    include_play_imports = True,
 )
 
 play_routes(
-  name = "play-routes-large",
-  srcs = ["conf/large.routes"],
-  include_play_imports = True,
+    name = "play-routes-large",
+    srcs = ["conf/large.routes"],
+    include_play_imports = True,
 )
 
 play_routes(
-  name = "play-routes-additional-imports",
-  srcs = ["conf/additional_imports.routes"],
-  include_play_imports = True,
-  routes_imports = [
-    "rulesplayroutes.test.User",
-    "rulesplayroutes.test.binders._",
-  ],
+    name = "play-routes-additional-imports",
+    srcs = ["conf/additional_imports.routes"],
+    include_play_imports = True,
+    routes_imports = [
+        "rulesplayroutes.test.User",
+        "rulesplayroutes.test.binders._",
+    ],
 )
 
 # TODO: StaticRoutesGenerator is removed in 2.7.X, figure out an alternative.
@@ -44,10 +44,10 @@ play_routes(
 # )
 
 play_routes(
-  name = "play-routes-reverse-router",
-  srcs = ["conf/reverse_router.routes"],
-  include_play_imports = True,
-  generate_reverse_router = True,
+    name = "play-routes-reverse-router",
+    srcs = ["conf/reverse_router.routes"],
+    generate_reverse_router = True,
+    include_play_imports = True,
 )
 
 # TOOD: Figure out what this does and add the test for it
@@ -60,26 +60,26 @@ play_routes(
 # )
 
 scala_test(
-  name = "play-routes-compiler-test",
-  srcs = glob(["app/**/*.scala"]) + [
-    "PlayRoutesCompilerTest.scala",
-    ":play-routes",
-    ":play-routes-large",
-    ":play-routes-basic1",
-    ":play-routes-basic2",
-    ":play-routes-additional-imports",
-    # ":play-routes-different-generator",
-    ":play-routes-reverse-router",
-    # ":play-routes-namespace-router",
-  ],
-  deps = [
-    "@play_routes_test//:org_specs2_specs2_common_2_12",
-    "@play_routes_test//:org_specs2_specs2_core_2_12",
-    "@play_routes_test//:org_specs2_specs2_matcher_2_12",
-    "@play_routes_test//:com_typesafe_akka_akka_actor_2_12",
-    "@play_routes_test//:com_typesafe_play_play_2_12",
-    "@play_routes_test//:com_typesafe_play_play_specs2_2_12",
-    "@play_routes_test//:com_typesafe_play_play_test_2_12",
-    "@play_routes_test//:com_typesafe_play_play_guice_2_12",
-  ]
+    name = "play-routes-compiler-test",
+    srcs = glob(["app/**/*.scala"]) + [
+        "PlayRoutesCompilerTest.scala",
+        ":play-routes",
+        ":play-routes-large",
+        ":play-routes-basic1",
+        ":play-routes-basic2",
+        ":play-routes-additional-imports",
+        # ":play-routes-different-generator",
+        ":play-routes-reverse-router",
+        # ":play-routes-namespace-router",
+    ],
+    deps = [
+        "@play_routes_test//:com_typesafe_akka_akka_actor_2_12",
+        "@play_routes_test//:com_typesafe_play_play_2_12",
+        "@play_routes_test//:com_typesafe_play_play_guice_2_12",
+        "@play_routes_test//:com_typesafe_play_play_specs2_2_12",
+        "@play_routes_test//:com_typesafe_play_play_test_2_12",
+        "@play_routes_test//:org_specs2_specs2_common_2_12",
+        "@play_routes_test//:org_specs2_specs2_core_2_12",
+        "@play_routes_test//:org_specs2_specs2_matcher_2_12",
+    ],
 )

--- a/workspace.bzl
+++ b/workspace.bzl
@@ -4,7 +4,7 @@ Load 3rd party maven dependencies
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
-def play_routes_repositories(play_version, scala_version=None):
+def play_routes_repositories(play_version, scala_version = None):
     """
     Loads 3rd party dependencies and the required play routes compiler CLIs for the specified version of Play
 


### PR DESCRIPTION
Depending on rules_play_routes from a project using Bazel 6 failed saying that there was an error in rules_play_routes. These dependency upgrades fixed the issues for that project.  